### PR TITLE
Bugfix of Ansi.cursor(RestorePos). 

### DIFF
--- a/src/hx/strings/ansi/Ansi.hx
+++ b/src/hx/strings/ansi/Ansi.hx
@@ -59,7 +59,7 @@ class Ansi {
             case MoveRight(columns): Ansi.ESC + columns + "C";
             case MoveLeft(columns): Ansi.ESC + columns + "D";
             case SavePos: Ansi.ESC + "s";
-            case RestorePos: Ansi.ESC + "s";
+            case RestorePos: Ansi.ESC + "u";
         }
     }
 


### PR DESCRIPTION
It was Ansi.ESC + "s" (same value as Ansi.cursor(SavePos))

Correct code is Ansi.ESC + "u" according to e.g.:

https://www.math.upenn.edu/~kazdan/210/computer/ansi.html
http://www.microvga.com/ansi-codes
