### PR TITLE
fix: Null safety error in CharIterator with Haxe 4.3.4

### DIFF
--- a/src/hx/strings/CharIterator.hx
+++ b/src/hx/strings/CharIterator.hx
@@ -134,16 +134,21 @@ class CharIterator {
       line = prevChar.line;
       col = prevChar.col;
 
-      prevBufferNextIdx = prevBufferPrevIdx + 1 < prevBuffer.length ? prevBufferPrevIdx + 1 : -1;
+      prevBufferNextIdx =  prevBufferPrevIdx + 1 < prevBufferLength ? prevBufferPrevIdx + 1 : -1;
       prevBufferPrevIdx--;
       return currChar;
    }
-
 
    inline
    public function hasNext():Bool
       return prevBufferNextIdx > -1 ? true : !isEOF();
 
+   private var prevBufferLength(get,never):Int;
+   
+   inline 
+   private function get_prevBufferLength():Int{
+      return @:nullSafety(Off) prevBuffer.length;
+   }
 
    /**
     * Moves to the next character in the input sequence and returns it.
@@ -157,8 +162,9 @@ class CharIterator {
          index = prevChar.index;
          line = prevChar.line;
          col = prevChar.col;
+
          prevBufferPrevIdx = prevBufferNextIdx - 1;
-         prevBufferNextIdx = prevBufferNextIdx + 1 < prevBuffer.length ? prevBufferNextIdx + 1 : -1;
+         prevBufferNextIdx = prevBufferNextIdx + 1 < prevBufferLength ? prevBufferNextIdx + 1 : -1;
          return currChar;
       }
 
@@ -176,7 +182,7 @@ class CharIterator {
 
       if (prevBuffer != null) {
          prevBuffer.add(new CharWithPos(currChar, index, col, line));
-         prevBufferPrevIdx = prevBuffer.length - 2;
+         prevBufferPrevIdx = prevBufferLength - 2;
          prevBufferNextIdx = -1;
       }
 

--- a/src/hx/strings/CharIterator.hx
+++ b/src/hx/strings/CharIterator.hx
@@ -100,6 +100,11 @@ class CharIterator {
    var prevBufferNextIdx = -1;
 
 
+   var prevBufferLength(get,never):Int; 
+   inline function get_prevBufferLength():Int
+      return @:nullSafety(Off) prevBuffer.length;
+
+
    public var current(get, never):Null<Char>;
    inline function get_current()
       return index > -1 ? currChar : null;
@@ -134,21 +139,16 @@ class CharIterator {
       line = prevChar.line;
       col = prevChar.col;
 
-      prevBufferNextIdx =  prevBufferPrevIdx + 1 < prevBufferLength ? prevBufferPrevIdx + 1 : -1;
+      prevBufferNextIdx = prevBufferPrevIdx + 1 < prevBufferLength ? prevBufferPrevIdx + 1 : -1;
       prevBufferPrevIdx--;
       return currChar;
    }
+
 
    inline
    public function hasNext():Bool
       return prevBufferNextIdx > -1 ? true : !isEOF();
 
-   private var prevBufferLength(get,never):Int;
-   
-   inline 
-   private function get_prevBufferLength():Int{
-      return @:nullSafety(Off) prevBuffer.length;
-   }
 
    /**
     * Moves to the next character in the input sequence and returns it.
@@ -162,7 +162,6 @@ class CharIterator {
          index = prevChar.index;
          line = prevChar.line;
          col = prevChar.col;
-
          prevBufferPrevIdx = prevBufferNextIdx - 1;
          prevBufferNextIdx = prevBufferNextIdx + 1 < prevBufferLength ? prevBufferNextIdx + 1 : -1;
          return currChar;


### PR DESCRIPTION
*Description of changes:* Fix multiple nulltype errors in Haxe 4.3.4 at the moment of getting the length of an array of a nulltype class

Fixes this error:
![image](https://github.com/vegardit/haxe-strings/assets/88955176/11e5f156-eb06-4a40-8200-aac8083712f6)
